### PR TITLE
Issue #8: load python 3.8 not 3.7

### DIFF
--- a/main/cluster/over.txt
+++ b/main/cluster/over.txt
@@ -1,0 +1,29 @@
+-------
+Copying input files to temporary run dir
+‘predict.py’ -> ‘/workspace/scratch/jobs/aolza/2433300/predict.py’
+‘randomForest.py’ -> ‘/workspace/scratch/jobs/aolza/2433300/randomForest.py’
+‘untitled0.py’ -> ‘/workspace/scratch/jobs/aolza/2433300/untitled0.py’
+‘versions.py’ -> ‘/workspace/scratch/jobs/aolza/2433300/versions.py’
+-------
+START python
+2021-12-20 12:09:16
+3.7.4.final.0
+1.0.0
+
+System:
+    python: 3.7.4 (default, Mar 18 2020, 20:37:21)  [GCC 8.3.0]
+executable: /workspace/easybuild/x86_64/software/Python/3.7.4-GCCcore-8.3.0/bin/python
+   machine: Linux-3.10.0-1062.el7.x86_64-x86_64-with-centos-7.7.1908-Core
+
+Python deps:
+       pip: 19.0.3
+setuptools: 41.2.0
+   sklearn: 0.21.3
+     numpy: 1.17.3
+     scipy: 1.5.4
+    Cython: 0.29.13
+    pandas: 0.25.3
+None
+-------
+Copying output files to home folder
+2021-12-20 12:09:36

--- a/main/cluster/predict.py
+++ b/main/cluster/predict.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Nov 25 09:59:25 2021
+
+@author: aolza
+"""
+import sys
+sys.path.append('/home/aolza/Desktop/estratificacion/')
+from python_settings import settings as config
+import json
+import joblib as job
+# import traceback as tb
+class Struct:
+    def __init__(self, **entries):
+        self.__dict__.update(entries)
+def configure(configname=None):
+    if not configname:
+        configname=input('Enter saved configuration file path: ')
+    with open(configname) as c:
+        configuration=json.load(c)
+    for k,v in configuration.items():
+        if isinstance(v,dict):#for example ACGFILES
+            try:
+                 configuration[k]= {int(yr):filename for yr,filename in v.items()}
+            except Exception as exc:
+                # print (tb.format_exc())
+                print (exc)
+    # print(configuration)
+    conf=Struct(**configuration)
+    conf.TRACEBACK=True
+    conf.VERBOSE=True
+    if not config.configured:
+        config.configure(conf) # configure() receives a python module
+    assert config.configured
+    # for statement in config.IMPORTS:  #FIXME is this ugly code?
+    #     exec(statement)
+    #     print(statement)
+    return configuration
+if not config.configured:
+    configure('/home/aolza/Desktop/estratificacion/configurations/used/randomForest20211217_153917.json')
+def performance(logistic,dat,predictors,probs=None,key='algunIngresoProg',file=None,mode='a',header='',AUC=True,**kwargs):
+    global config
+    if not config.configured:
+        configuration,config=configure()
+    N=kwargs.get('N',0)
+    
+    if file is not None:
+        file = open(file, mode)
+    if probs is None:
+        probs=logistic.predict_proba(dat[predictors])[:,1] #Probab de ingreso
+    print('N=',N,file=file)
+    print('Numb unique probs ',len(np.unique(probs)),file=file)
+    if AUC:
+        auc=roc_auc_score(dat[key], probs)
+        print('AUC=',auc,file=file)
+    return(probs)
+def predict_save(yr,model,X,y,columns=config.COLUMNS[0]):
+
+    from more_itertools import sliced
+    CHUNK_SIZE = 50000
+    
+    index_slices = sliced(range(len(X)), CHUNK_SIZE)
+    i=0
+    n=len(X)/CHUNK_SIZE
+    with open(config.PREDFILES[yr-1],'w') as predFile:
+        csv_out=csv.writer(predFile)
+        csv_out.writerow(['PATIENT_ID','PRED','OBS'])
+        for index_slice in index_slices:
+            i+=1
+            util.vprint(i,'/',n)
+            chunk = X.iloc[index_slice] # your dataframe chunk ready for use
+            ychunk=y.iloc[index_slice]
+            predictions=model.predict_proba(chunk.drop('PATIENT_ID',axis=1))[:,1] #Probab of being top1
+            for element in zip(chunk['PATIENT_ID'],ychunk['PATIENT_ID'],predictions,ychunk[columns]):
+                csv_out.writerow(element)
+                del element
+    print('saved',config.PREDFILES[yr-1]) 
+ 
+    #%%
+import csv
+import pandas as pd
+import configurations.utility as util
+# from dataManipulation.generarTablasVariables import load
+from dataManipulation.dataPreparation import getData
+from sklearn.metrics import roc_auc_score
+import numpy as np
+from sklearn import linear_model
+from main.SafeLogisticRegression import SafeLogisticRegression
+import importlib
+#%%
+if __name__=='__main__':
+        
+    # FIXME STRUCT KEYS TO INT, FIX GENERARTABLASVARIABLES.RETRIEVE INDICE
+    configname='/home/aolza/Desktop/estratificacion/configurations/used/randomForest20211217_153917.json'
+    # configuration=configure(configname)
+    modelfilename='/home/aolza/Desktop/estratificacion/models/urgcms_excl_hdia_nbinj/randomForest20211217_153917.joblib'
+    success=False
+    while not success:
+        try:
+            model=job.load(modelfilename)
+            success=True
+        except Exception as exc:#FIXME this does not work
+            print(str(exc))
+            print('Importing ',str(exc).split(' ')[-1])
+            module=importlib.import_module(str(exc).split(' ')[-1])
+            print('Imported ',str(exc).split(' ')[-1])
+    Xx,Yy=getData(2017)
+    # x,y=getData(2017,oldbase=True)
+    cols=list(Xx.columns)
+    if 'ingresoUrg' in cols: cols.remove('ingresoUrg')
+  
+    predict_save(2018, model, Xx, Yy)
+    probs=pd.read_csv(config.PREDFILES[2017])
+
+    print(roc_auc_score(np.where(probs.OBS>=1,1,0), probs.PRED))
+    # oldprobs=pd.read_csv('untracked/predecirIngresos/logistica/urgSinPrevio18.csv')
+    # oldauc=roc_auc_score(np.where(y.ingresoUrg>=1,1,0), oldprobs.PROB_ING)
+

--- a/main/cluster/predict.sl
+++ b/main/cluster/predict.sl
@@ -1,0 +1,28 @@
+#!/bin/bash
+#SBATCH--time=03:00:00
+#SBATCH--job-name="pred"
+#SBATCH --mem-per-cpu=16G
+#SBATCH--partition="medium"
+#SBATCH--output=/home/aolza/Desktop/estratificacion/main/cluster/outpred.txt
+#SBATCH--error=/home/aolza/Desktop/estratificacion/main/cluster/errpred.txt
+echo "-------" 
+echo "Copying input files to temporary run dir" 
+cp *.py -v $SCRATCH_JOB
+
+cd $SCRATCH_JOB
+echo "-------" 
+echo "START python" 
+date +"%F %T" 
+module load python-settings/0.2.2-GCCcore-10.2.0-Python-3.8.6
+module load SciPy-bundle
+module load scikit-learn
+srun python predict.py
+
+sleep 2
+echo "-------" 
+echo "Copying output files to home folder" 
+date +"%F %T" 
+
+cp -r $SCRATCH_JOB  /home/aolza/$SLURM_JOB_ID
+chmod -R 770 /home/aolza/$SLURM_JOB_ID
+

--- a/main/cluster/predict.sl
+++ b/main/cluster/predict.sl
@@ -15,7 +15,6 @@ echo "START python"
 date +"%F %T" 
 module load python-settings/0.2.2-GCCcore-10.2.0-Python-3.8.6
 module load SciPy-bundle
-module load scikit-learn
 srun python predict.py
 
 sleep 2

--- a/main/cluster/randomForest.sl
+++ b/main/cluster/randomForest.sl
@@ -15,7 +15,6 @@ echo "START python"
 date +"%F %T" 
 module load python-settings/0.2.2-GCCcore-10.2.0-Python-3.8.6
 module load SciPy-bundle
-module load scikit-learn
 srun python randomForest.py configRandomForest urgcms_excl_hdia_nbinj
 
 sleep 2

--- a/main/cluster/randomForestxl.sl
+++ b/main/cluster/randomForestxl.sl
@@ -14,7 +14,6 @@ echo "START python"
 date +"%F %T" 
 module load python-settings/0.2.2-GCCcore-10.2.0-Python-3.8.6
 module load SciPy-bundle
-module load scikit-learn
 srun python randomForest.py
 
 sleep 2

--- a/main/cluster/untitled.sl
+++ b/main/cluster/untitled.sl
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH--time=03:00:00
+#SBATCH--job-name="unt"
+#SBATCH --mem-per-cpu=16G
+#SBATCH--partition="medium"
+#SBATCH--output=/home/aolza/Desktop/estratificacion/main/cluster/outunt.txt
+#SBATCH--error=/home/aolza/Desktop/estratificacion/main/cluster/errunt.txt
+echo "-------" 
+echo "Copying input files to temporary run dir" 
+cp *.py -v $SCRATCH_JOB
+
+cd $SCRATCH_JOB
+echo "-------" 
+echo "START python" 
+date +"%F %T"
+module load Python/3.8.6-GCCcore-10.2.0
+ 
+module load python-settings/0.2.2-GCCcore-10.2.0-Python-3.8.6
+module load SciPy-bundle
+module load scikit-learn
+srun python untitled0.py configRandomForest urgcms_excl_hdia_nbinj
+
+sleep 2
+echo "-------" 
+echo "Copying output files to home folder" 
+date +"%F %T" 
+
+cp -r $SCRATCH_JOB  /home/aolza/$SLURM_JOB_ID
+chmod -R 770 /home/aolza/$SLURM_JOB_ID
+

--- a/main/cluster/untitled.sl
+++ b/main/cluster/untitled.sl
@@ -17,7 +17,6 @@ module load Python/3.8.6-GCCcore-10.2.0
  
 module load python-settings/0.2.2-GCCcore-10.2.0-Python-3.8.6
 module load SciPy-bundle
-module load scikit-learn
 srun python untitled0.py configRandomForest urgcms_excl_hdia_nbinj
 
 sleep 2

--- a/main/cluster/versions.py
+++ b/main/cluster/versions.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Dec 20 11:36:16 2021
+
+@author: aolza
+"""
+import importlib
+import joblib
+import sys
+import sklearn as ens
+# from importlib.metadata import version
+# print(version('importlib'))
+# from getversion import get_module_version
+def get_builtin_module_version(module ):
+    # type: (...) -> str
+    """
+    It the module is in the list of builtin module names, the python version is returned as suggested by PEP396
+    See https://www.python.org/dev/peps/pep-0396/#specification
+    :param module:
+    :return:
+    """
+    # if module.__name__ in sys.builtin_module_names:  # `imp.is_builtin` also works but maybe less efficient
+        # what about this ?
+        # from platform import python_version
+        # python_version()
+        # https://stackoverflow.com/a/25477839/7262247
+
+        # full python version
+    sys_version = '.'.join([str(v) for v in sys.version_info])
+    return sys_version
+    # else:
+    #     raise ValueError("Module %s is not a built-in module" % module.__name__)
+version = get_builtin_module_version(importlib)
+print(version)
+
+version2 = joblib.__version__
+print(version2)
+
+print(ens.show_versions())

--- a/main/cluster/versions.sl
+++ b/main/cluster/versions.sl
@@ -1,0 +1,27 @@
+#!/bin/bash
+#SBATCH--time=00:30:00
+#SBATCH--job-name="ver"
+#SBATCH --mem-per-cpu=6G
+#SBATCH--partition="short"
+#SBATCH--output=/home/aolza/Desktop/estratificacion/main/cluster/over.txt
+#SBATCH--error=/home/aolza/Desktop/estratificacion/main/cluster/ever.txt
+echo "-------" 
+echo "Copying input files to temporary run dir" 
+cp *.py -v $SCRATCH_JOB
+
+cd $SCRATCH_JOB
+echo "-------" 
+echo "START python" 
+date +"%F %T" 
+module load python-settings/0.2.2-GCCcore-10.2.0-Python-3.8.6
+module load SciPy-bundle
+module load scikit-learn
+srun python versions.py
+sleep 2
+echo "-------" 
+echo "Copying output files to home folder" 
+date +"%F %T" 
+
+cp -r $SCRATCH_JOB  /home/aolza/$SLURM_JOB_ID
+chmod -R 770 /home/aolza/$SLURM_JOB_ID
+

--- a/main/cluster/versions.sl
+++ b/main/cluster/versions.sl
@@ -15,7 +15,6 @@ echo "START python"
 date +"%F %T" 
 module load python-settings/0.2.2-GCCcore-10.2.0-Python-3.8.6
 module load SciPy-bundle
-module load scikit-learn
 srun python versions.py
 sleep 2
 echo "-------" 


### PR DESCRIPTION
> El módulo de scikit-learn/0.21.3-intel-2019b-Python-3.7.4 es el que te está dando problemas, ya que pertenece a una versión de Python anterior, y en este caso no te haría falta cargarlo, puesto que se encuentra incluido en el módulo de Scipy-Bundle.

When doing `module load scikit-learn` in my bash scripts, this was triggering a downgrade to python 3.7.4 which is incompatible with the 3.8.5 installed in my local system, and thus I am unable to use joblib across both computers (issue #8 ).